### PR TITLE
Added weapon blacklist

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -169,6 +169,16 @@ Citizen.CreateThread(function()
 	end
 end)
 
+function BlackListCheck(playerPed)
+	for i=1,#Config.WeaponBlacklist do
+		local weaponHash = GetHashKey(Config.WeaponBlacklist[i])
+		if GetSelectedPedWeapon(playerPed) == weaponHash then
+			return false -- Is a blacklisted weapon
+		end
+	end
+	return true -- Is not a blacklisted weapon
+end
+
 Citizen.CreateThread(function()
 	while true do
 		Citizen.Wait(0)
@@ -216,7 +226,7 @@ Citizen.CreateThread(function()
 				}, streetName, playerGender)
 			end
 
-		elseif IsPedShooting(playerPed) and not IsPedCurrentWeaponSilenced(playerPed) and Config.GunshotAlert then
+		elseif IsPedShooting(playerPed) and not IsPedCurrentWeaponSilenced(playerPed) and Config.GunshotAlert and BlackListCheck(playerPed) then
 
 			Citizen.Wait(3000)
 

--- a/config.lua
+++ b/config.lua
@@ -39,3 +39,21 @@ Config.ShowCopsMisbehave = true
 Config.WhitelistedCops = {
 	'police'
 }
+
+-- Weapons that do not count as gunshots.
+Config.WeaponBlacklist = {
+	'WEAPON_GRENADE',
+	'WEAPON_BZGAS',
+	'WEAPON_MOLOTOV',
+	'WEAPON_STICKYBOMB',
+	'WEAPON_PROXMINE',
+	'WEAPON_SNOWBALL',
+	'WEAPON_PIPEBOMB',
+	'WEAPON_BALL',
+	'WEAPON_SMOKEGRENADE',
+	'WEAPON_FLARE',
+	'WEAPON_PETROLCAN',
+	'WEAPON_FIREEXTINGUISHER',
+	'WEAPON_HAZARDCAN',
+	'WEAPON_STUNGUN'
+}


### PR DESCRIPTION
This adds certain weapons to a weapon blacklist where it does not show "shootout in progress" for these. For example: a baseball. No need to call the police when the kid down the street throws a baseball. Same with the snowball, etc. Feel free to adjust the array as needed... That's just how I had my server configured.